### PR TITLE
feat: customError, BaseTimeEntity 생성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### Custom (local config 제외) ###
+application-local.yml

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ repositories {
 }
 
 dependencies {
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'

--- a/src/main/java/com/Hangover/DGU_Graduation/DguGraduationApplication.java
+++ b/src/main/java/com/Hangover/DGU_Graduation/DguGraduationApplication.java
@@ -2,8 +2,10 @@ package com.Hangover.DGU_Graduation;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class DguGraduationApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/Hangover/DGU_Graduation/common/config/OpenApiConfig.java
+++ b/src/main/java/com/Hangover/DGU_Graduation/common/config/OpenApiConfig.java
@@ -1,0 +1,43 @@
+package com.Hangover.DGU_Graduation.common.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.media.IntegerSchema;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.media.StringSchema;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI customOpenAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Hangover API")
+                        .description("JWT 기반 인증을 사용하는 API 문서입니다. (현재 Security 미구현 상태)")
+                        .version("v1.0.0"))
+                // Swagger UI에 Bearer Auth 입력창 추가
+                .addSecurityItem(new SecurityRequirement().addList("Bearer Authentication"))
+                .components(new Components()
+                        // JWT Bearer 스키마 정의
+                        .addSecuritySchemes("Bearer Authentication",
+                                new SecurityScheme()
+                                        .name("Authorization")
+                                        .description("JWT Bearer 토큰을 입력하세요. (예: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...)")
+                                        .type(SecurityScheme.Type.HTTP)
+                                        .scheme("bearer")
+                                        .bearerFormat("JWT")
+                        )
+                        // 공통 에러 응답 스키마
+                        .addSchemas("ErrorResponse", new Schema<>()
+                                .addProperty("status", new IntegerSchema().example(400))
+                                .addProperty("code", new StringSchema().example("U001"))
+                                .addProperty("message", new StringSchema().example("사용자를 찾을 수 없습니다."))
+                        )
+                );
+    }
+}

--- a/src/main/java/com/Hangover/DGU_Graduation/common/controller/GlobalExceptionHandler.java
+++ b/src/main/java/com/Hangover/DGU_Graduation/common/controller/GlobalExceptionHandler.java
@@ -1,0 +1,103 @@
+package com.Hangover.DGU_Graduation.common.controller;
+
+
+import com.Hangover.DGU_Graduation.common.dto.ErrorResponse;
+import com.Hangover.DGU_Graduation.common.exception.CustomException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * 전역 예외 처리기(Global Exception Handler)
+ */
+@RestControllerAdvice
+@Slf4j
+public class GlobalExceptionHandler {
+
+    //CustomException 던져지면 메소드 호출
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ErrorResponse> handleCustomException(CustomException e) {
+        // 예외 정보 로그
+        log.warn("CustomException: code={}, msg={}", e.getErrorCode().getCode(), e.getMessage());
+
+        // ErrorCode 내부에 미리 정의된 HTTP 상태를 사용하여 응답 생성
+        return ResponseEntity
+                .status(e.getErrorCode().getStatus())          // 400, 401, 404 등
+                .body(ErrorResponse.of(e.getErrorCode()));     // 통일된 포맷의 에러 응답 바디
+    }
+
+    // @Valid 검증 실패
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleValidationException(MethodArgumentNotValidException e) {
+        String fallback = "요청 값이 올바르지 않습니다.";
+        var fieldErrors = e.getBindingResult().getFieldErrors();
+
+        //대표메시지 뽑기
+        String topMessage = fieldErrors.isEmpty()
+                ? fallback
+                : Optional.ofNullable(fieldErrors.get(0).getDefaultMessage())
+                .filter(msg -> !msg.isBlank())
+                .orElse(fallback);
+
+        //로그용 상세 메시지
+        var detailsForLog = fieldErrors.stream()
+                .map(fe -> Map.of(
+                        "field", fe.getField(),
+                        "rejected", maskIfSensitive(fe.getField(), fe.getRejectedValue()),
+                        "message", Objects.requireNonNull(fe.getDefaultMessage())
+                ))
+                .toList();
+
+        log.debug("Validation failed: topMessage={}, details={}", topMessage, detailsForLog);
+
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(new ErrorResponse(400, "C001", topMessage));
+    }
+
+    //지원하지 않는 메서드
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<ErrorResponse> handleMethodNotSupported(HttpRequestMethodNotSupportedException e) {
+        log.warn("Method not supported: {}", e.getMethod());
+        return ResponseEntity
+                .status(HttpStatus.METHOD_NOT_ALLOWED)
+                .body(new ErrorResponse(405, "M001", "지원하지 않는 HTTP 메서드입니다."));
+    }
+
+    // JSON parse 에러
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ErrorResponse> handleMessageNotReadable(HttpMessageNotReadableException e) {
+        log.warn("Message not readable: {}", e.getMessage());
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(new ErrorResponse(400, "J001", "잘못된 요청 형식입니다."));
+    }
+
+    // 예상 못한 예외 (서버 에러)
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleException(Exception e) {
+        log.error("Unexpected exception", e);
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(new ErrorResponse(500, "E999", "서버 내부 오류가 발생했습니다."));
+    }
+
+    // 유틸: 민감값 마스킹
+    private String maskIfSensitive(String field, Object rejected) {
+        if (field == null) return "";
+        String f = field.toLowerCase();
+        if (f.contains("password") || f.contains("pwd")) return "****";
+        return rejected == null ? "" : String.valueOf(rejected);
+    }
+
+
+}

--- a/src/main/java/com/Hangover/DGU_Graduation/common/domain/BaseTimeEntity.java
+++ b/src/main/java/com/Hangover/DGU_Graduation/common/domain/BaseTimeEntity.java
@@ -1,0 +1,28 @@
+package com.Hangover.DGU_Graduation.common.domain;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+/**
+ * BaseTimeEntity 생성
+ */
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseTimeEntity {
+
+    //만든시간
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    //수정시간
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+}

--- a/src/main/java/com/Hangover/DGU_Graduation/common/dto/ApiResponseDto.java
+++ b/src/main/java/com/Hangover/DGU_Graduation/common/dto/ApiResponseDto.java
@@ -1,0 +1,27 @@
+package com.Hangover.DGU_Graduation.common.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * 공통 성공 응답
+ */
+@Getter
+@AllArgsConstructor
+public class ApiResponseDto<T> {
+
+    @Schema(description = "HTTP 상태 코드", example = "200")
+    private int status;
+
+    @Schema(description = "응답 메시지", example = "성공")
+    private String message;
+
+    @Schema(description = "실제 데이터")
+    private T data;
+
+    public static <T> ApiResponseDto<T> success(String message, T data) {
+        return new ApiResponseDto<>(200, message, data); //성공은 200으로 통일
+    }
+
+}

--- a/src/main/java/com/Hangover/DGU_Graduation/common/dto/ErrorResponse.java
+++ b/src/main/java/com/Hangover/DGU_Graduation/common/dto/ErrorResponse.java
@@ -1,0 +1,26 @@
+package com.Hangover.DGU_Graduation.common.dto;
+
+import com.Hangover.DGU_Graduation.common.exception.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 공통 에러 response
+ */
+@Getter
+@Builder
+@AllArgsConstructor
+public class ErrorResponse {
+    private int status;
+    private String code;
+    private String message;
+
+    public static ErrorResponse of(ErrorCode errorCode) {
+        return new ErrorResponse(
+                errorCode.getStatus(),
+                errorCode.getCode(),
+                errorCode.getMessage()
+        );
+    }
+}

--- a/src/main/java/com/Hangover/DGU_Graduation/common/exception/CustomException.java
+++ b/src/main/java/com/Hangover/DGU_Graduation/common/exception/CustomException.java
@@ -1,0 +1,24 @@
+package com.Hangover.DGU_Graduation.common.exception;
+
+
+import lombok.Getter;
+
+/**
+ * CustomException 생성
+ */
+@Getter
+public class CustomException extends RuntimeException {
+
+    //errorCode
+    private final ErrorCode errorCode;
+
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public CustomException(ErrorCode errorCode, String message) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/Hangover/DGU_Graduation/common/exception/ErrorCode.java
+++ b/src/main/java/com/Hangover/DGU_Graduation/common/exception/ErrorCode.java
@@ -1,0 +1,7 @@
+package com.Hangover.DGU_Graduation.common.exception;
+
+public interface ErrorCode {
+    int getStatus();
+    String getCode();
+    String getMessage();
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=DGU_Graduation

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,30 @@
+spring:
+  application:
+    name: hangover-project
+
+  profiles:
+    active: local   # ?? ??? local ???? ??
+
+  jpa:
+    hibernate:
+      ddl-auto: update   # ?? ????? update (??? validate ??)
+    properties:
+      hibernate:
+        format_sql: true
+        dialect: org.hibernate.dialect.MySQLDialect
+    open-in-view: false
+
+logging:
+  level:
+    org.hibernate.SQL: debug
+    org.hibernate.type.descriptor.sql.BasicBinder: trace
+
+server:
+  port: 8081
+
+---
+spring:
+  config:
+    activate:
+      on-profile: local
+


### PR DESCRIPTION
close #3 

BaseTimeEntity 생성
@MappedSuperclass로 생성일자(createdAt), 수정일자(updatedAt) 자동 관리
JPA Auditing 기능 적용

커스텀 에러 클래스 추가
공통 예외 처리 구조화
도메인별 에러 코드/메시지를 명확히 관리할 수 있도록 설계 