### PR TITLE
refactor: 응답 포멧 하나로 설정

### DIFF
--- a/src/main/java/com/Hangover/DGU_Graduation/common/controller/ResponseInterceptor.java
+++ b/src/main/java/com/Hangover/DGU_Graduation/common/controller/ResponseInterceptor.java
@@ -1,0 +1,61 @@
+package com.Hangover.DGU_Graduation.common.controller;
+
+
+import com.Hangover.DGU_Graduation.common.dto.ApiResponseDto;
+import com.Hangover.DGU_Graduation.common.dto.ErrorResponse;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.MediaType;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.http.server.ServletServerHttpResponse;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+
+@RestControllerAdvice
+public class ResponseInterceptor implements ResponseBodyAdvice<Object> {
+
+    @Override
+    public boolean supports(MethodParameter returnType, Class converterType) {
+        return true; // 모든 컨트롤러 응답에 적용
+    }
+
+    @Override
+    public Object beforeBodyWrite(Object body,
+                                  MethodParameter returnType,
+                                  MediaType selectedContentType,
+                                  Class selectedConverterType,
+                                  ServerHttpRequest request,
+                                  ServerHttpResponse response) {
+
+        // Swagger / API 문서 요청은 제외
+        String path = request.getURI().getPath();
+        if (path.contains("swagger") || path.contains("api-docs") || path.contains("webjars")) {
+            return body;
+        }
+
+        // 에러 응답은 그대로 전달
+        if (body instanceof ErrorResponse || body instanceof ApiResponseDto) {
+            return body;
+        }
+
+        // 현재 HTTP status
+        int status = ((ServletServerHttpResponse) response).getServletResponse().getStatus();
+
+        // ApiResponseDto로 래핑
+        ApiResponseDto<Object> apiResponse = ApiResponseDto.success(status, body);
+
+        // String 응답일 경우 Jackson 변환 필요
+        if (body instanceof String) {
+            try {
+                ObjectMapper objectMapper = new ObjectMapper();
+                return objectMapper.writeValueAsString(apiResponse);
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException("String response conversion error", e);
+            }
+        }
+
+        return apiResponse;
+    }
+}

--- a/src/main/java/com/Hangover/DGU_Graduation/common/dto/ApiResponseDto.java
+++ b/src/main/java/com/Hangover/DGU_Graduation/common/dto/ApiResponseDto.java
@@ -3,6 +3,7 @@ package com.Hangover.DGU_Graduation.common.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import org.springframework.http.HttpStatus;
 
 /**
  * 공통 성공 응답
@@ -20,8 +21,16 @@ public class ApiResponseDto<T> {
     @Schema(description = "실제 데이터")
     private T data;
 
-    public static <T> ApiResponseDto<T> success(String message, T data) {
-        return new ApiResponseDto<>(200, message, data); //성공은 200으로 통일
+    // --- 정적 팩토리 메서드 ---
+
+    /**
+     * 성공 응답 (상태 코드 지정, 메시지는 기본 "성공")
+     */
+    public static <T> ApiResponseDto<T> success(int status, T data) {
+        return new ApiResponseDto<>(status, "성공", data);
     }
 
+    public static <T> ApiResponseDto<T> success(int status, String message, T data) {
+        return new ApiResponseDto<>(status, message, data);
+    }
 }


### PR DESCRIPTION
close #7 

return ResponseEntity.noContent().build(); 204(delete일때 noContent)
 return ResponseEntity.status(HttpStatus.OK).body(null); //반환값이 data가 없을때

기본적으로는
return ResponseEntity.status(HttpStatus.CREATED).body(tokenResponse); 로 꺼내오고 상태메시지 추가하고싶으면

return ResponseEntity.status(HttpStatus.CREATED)
            .body(ApiResponseDto.success(201, "회원가입 성공", createdUser));
식으로 넣으면될듯요